### PR TITLE
Switch away from deprecated setup-android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,7 +14,4 @@ jobs:
 #       with:
 #         java-version: 1.8
     - name: Build with Gradle
-      uses: msfjarvis/setup-android@1.0
-      with:
-        entrypoint: ./gradlew
-        args: dependencies assembleDebug
+      run: ./gradlew dependencies assembleDebug


### PR DESCRIPTION
I am in the process of deprecating setup-android as GitHub Actions now ships default containers with everything that's needed.