### PR TITLE
Feature/deprecate setup android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,7 +14,4 @@ jobs:
 #       with:
 #         java-version: 1.8
     - name: Build with Gradle
-      uses: msfjarvis/setup-android@1.0
-      with:
-        entrypoint: ./gradlew
-        args: dependencies assembleDebug
+      run: ./gradlew dependencies assembleDebug

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ apply plugin: "androidx.navigation.safeargs"
 
 android {
     compileSdkVersion 29
-    buildToolsVersion '29.0.3'
+    buildToolsVersion '29.0.2'
 
     defaultConfig {
         applicationId "li.doerf.hacked"


### PR DESCRIPTION
@msfjarvis: I tried to merge your request into a feature branch, but now i get this error ... can you help me out here. You can also see the link to the ci job below. Thanks. 

```
Warning: Failed to read or create install properties file.

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':app:compileDebugJavaWithJavac'.
> Failed to install the following SDK components:
      build-tools;29.0.3 Android SDK Build-Tools 29.0.3
  The SDK directory is not writable (/usr/local/lib/android/sdk)


Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.2/userguide/command_line_interface.html#sec:command_line_warnings

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 45s
##[error]Process completed with exit code 1.
```